### PR TITLE
Added support for array of ast objects.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,17 @@ function analyseSources (sources, options, parserOptions) {
 
 function mapSource (options, parserOptions, source) {
     try {
-        return {
-            path: source.path,
-            ast: getSyntaxTree(source.code, parserOptions)
-        };
+        if (source.ast) {
+            return {
+                path: source.path,
+                ast: source.ast
+            };
+        } else if (source.code) {
+            return {
+                path: source.path,
+                ast: getSyntaxTree(source.code, parserOptions)
+            };
+        }
     } catch (error) {
         if (options.ignoreErrors) {
             return null;
@@ -53,5 +60,13 @@ function performAnalysis (ast, options) {
 }
 
 function analyseSource (source, options, parserOptions) {
-    return performAnalysis(getSyntaxTree(source, parserOptions), options);
+    if (typeof source === 'string') {
+        return performAnalysis(getSyntaxTree(source, parserOptions), options);
+    } else if (typeof source === 'object') {
+        return performAnalysis(source, options);
+    } else {
+        throw new Error('Invalid source');
+    }
+
+
 }


### PR DESCRIPTION
I've modified two things: 

1) When the source is an object then it assumes it is an AST object and performs the analysis on it instead of assuming it's a path to a file.

2) When supplied with an array, if the array has the following format: 

```
[ 
    {
        path: 'path/to/file',
        ast: {astObj}
    }
    ...
]
```

Then it skips getting the AST and immediately runs the analysis. These modifications allowed my algorithm which ran with escomplex version 1.3.0 to work and I think they do not interfere with the refactoring being done with version 2.0. 
