### PR TITLE
feat: support analyze vue file

### DIFF
--- a/src/ESComplex.js
+++ b/src/ESComplex.js
@@ -70,6 +70,13 @@ export default class ESComplex
       /* istanbul ignore if */
       if (typeof source !== 'string') { throw new TypeError(`analyze error: 'source' is not a 'string'.`); }
 
+      if (options && ['.vue', 'vue'].includes(options.extName)) {
+         let matchRes = source.match(/<script\b[^>]*>[\s\S]*<\/script>/g);
+         if (matchRes) {
+            source = matchRes[0].replace(/(<script\b[^>]*>)|(<\/script>)/g, '');
+         }
+      }
+
       return this._escomplexModule.analyze(BabelParser.parse(source, parserOptions, parserOverride), options);
    }
 

--- a/test/src/index/index.js
+++ b/test/src/index/index.js
@@ -272,6 +272,34 @@ if (testconfig.modules['index'])
                assert.strictEqual(results.modules[1].aggregate.sloc.logical, 2);
             });
          });
+
+         test('test .vue file support ', () =>
+         {
+            const sources = '<template><div>test for vue</div></template> <script lang="javascript">export default { data () {return {foo: 1}}}</script>';
+
+            escomplex.analyzeModuleAsync(sources, { extName: 'vue' }).then((results) => {
+               assert.isObject(results);
+               assert.strictEqual(results.aggregate.sloc.logical, 3);
+            });
+         });
+
+         test('test .vue file using typescript', () =>
+         {
+            const sources = '<template><div>test for vue</div></template> <script lang="javascript">@Component export default class Test {readonly test = 1;}</script>';
+
+            escomplex.analyzeModuleAsync(
+               sources, 
+               { extName: 'vue' }, 
+               undefined, 
+               {
+                  decoratorsBeforeExport: true,
+                  decoratorsLegacy: true
+               }).then((results) => {
+               assert.isObject(results);
+               assert.strictEqual(results.aggregate.sloc.logical, 1);
+            });
+         });
+
       });
    });
 }


### PR DESCRIPTION
fix: #28 

## PR Checklist

 - [x] Add Unit tests and all cases passed

![image](https://user-images.githubusercontent.com/25732253/123035205-8a0a4100-d41d-11eb-84d6-9bc539f4ebe1.png)

## How to slove

I have two way to solve it.

- The first is:

A typical vue file has two or three parts, `<template></template>`、`<script></script>` and maybe has `<style></style>`.

So we can split `<script>` from source, and pass it to BabelParser.

- The second is:

Pass an option `extName`, and what we should do is the same as above.

I choose the second one. Beacuse I think it's good for us to handle more file in the future.

## What is the current behavior?

**Vue file**

```js
const sources = '<template><div>test for vue</div></template> <script lang="javascript">export default { data () {return {foo: 1}}}</script>';

escomplex.analyzeModule(sources, { extName: 'vue' })
```

**Vue file written by typescript**

```js
const sources = '<template><div>test for vue</div></template> <script lang="javascript">@Component export default class Test {readonly test = 1;}</script>';

escomplex.analyzeModule(
   sources, 
   { extName: 'vue' }, 
   undefined, 
   {
      decoratorsBeforeExport: true,
      decoratorsLegacy: true
   })
```


